### PR TITLE
SAML single sign-on support

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -25,6 +25,10 @@ jobs:
     - uses: actions/setup-python@v2
       with:
         python-version: '3.8'
+    - name: Install prerequistes for SAML
+      if: ${{ matrix.env == 'pylint' }}
+      run: |
+        sudo apt-get install libxml2-dev libxmlsec1-dev libxmlsec1-openssl
     - name: Install build tools
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,6 +29,9 @@ jobs:
     - uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
+    - name: Install prerequistes for SAML
+      run: |
+        sudo apt-get install libxml2-dev libxmlsec1-dev libxmlsec1-openssl
     - name: Install build tools
       run: |
         python -m pip install --upgrade pip

--- a/README.rst
+++ b/README.rst
@@ -59,6 +59,23 @@ The easiest way to install *django-cloudprojects* is with pip:
 
     pip install django-cloudprojects
 
+SAML support is available as an installation option:
+
+.. code:: console
+
+    pip install django-cloudprojects[saml]
+
+Note that SAML support requires additional libraries installed on your target
+system, e.g. for Debian/Ubuntu- and RedHat/CentOS-based systems:
+
+.. code:: console
+
+   sudo apt-get install libxml2-dev libxmlsec1-dev libxmlsec1-openssl
+
+.. code:: console
+
+   sudo yum install libxml2-devel xmlsec1-devel xmlsec1-openssl-devel libtool-ltdl-devel
+
 Basic Usage
 ===========
 
@@ -74,6 +91,7 @@ Basic Usage
         'django.contrib.messages',
         'django.contrib.sites',
         ...
+        # 'django_saml',
         'allauth',
         'allauth.account',
         'allauth.socialaccount',
@@ -85,6 +103,7 @@ Basic Usage
 
     AUTHENTICATION_BACKENDS = [
         'django.contrib.auth.backends.ModelBackend',
+        'django_saml.backends.SamlUserBackend',
         'allauth.account.auth_backends.AuthenticationBackend',
     ]
 
@@ -126,6 +145,9 @@ Basic Usage
    values during deployment.  See our `test project`_ for a suggestion on how
    an implementation may look like.
 
+5. If you intend to use SAML you need to add all required settings to your
+   project's Django settings, as described in the `python3-saml-django docs`_.
+
 
 .. _Allauth documentation:
     https://django-allauth.readthedocs.io/en/latest/providers.html
@@ -137,3 +159,5 @@ Basic Usage
     https://django-allauth.readthedocs.io/en/latest/providers.html#bitbucket
 .. _test project:
     https://github.com/painless-software/django-cloudprojects/tree/main/tests/testproject
+.. _python3-saml-django docs:
+    https://pypi.org/project/python3-saml-django/

--- a/cloudprojects/urls.py
+++ b/cloudprojects/urls.py
@@ -4,6 +4,17 @@ URL configuration for django-cloudprojects.
 
 from django.urls import include, path
 
-urlpatterns = [
+urlpatterns = []
+
+try:
+    import django_saml
+
+    urlpatterns = [
+        path('saml/', django_saml.urls),
+    ]
+except ImportError:
+    pass
+
+urlpatterns += [
     path('', include('allauth.urls')),
 ]

--- a/setup.py
+++ b/setup.py
@@ -50,6 +50,9 @@ setup(
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
     ],
+    extras_require={
+        'saml': ['python3-saml-django'],
+    },
     install_requires=[
         'django-allauth',
     ],

--- a/tests/testproject/project/settings.py
+++ b/tests/testproject/project/settings.py
@@ -35,6 +35,7 @@ INSTALLED_APPS = [
     'django.contrib.messages',
     'django.contrib.staticfiles',
     'django.contrib.sites',
+    'django_saml',
     'allauth',
     'allauth.account',
     'allauth.socialaccount',
@@ -74,6 +75,7 @@ TEMPLATES = [
 
 AUTHENTICATION_BACKENDS = [
     'django.contrib.auth.backends.ModelBackend',
+    'django_saml.backends.SamlUserBackend',
     'allauth.account.auth_backends.AuthenticationBackend',
 ]
 
@@ -104,3 +106,36 @@ USE_TZ = True
 # https://docs.djangoproject.com/en/stable/howto/static-files/
 
 STATIC_URL = '/static/'
+
+# SAML configuration
+# https://pypi.org/project/python3-saml-django/
+
+SAML_SP = {
+    "entityId": "https://example.com/saml/metadata/",
+    "assertionConsumerService": {
+        "url": "https://example.com/saml/acs/",
+        "binding": "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST"
+    },
+    "singleLogoutService": {
+        "url": "https://example.com/saml/sls/",
+        "binding": "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect"
+    },
+    "NameIDFormat": "urn:oasis:names:tc:SAML:2.0:nameid-format:unspecified",
+    "x509cert": "<can also be loaded by file, see SAML_BASE_DIRECTORY>",
+    "privateKey": "<can also be loaded by file, see SAML_BASE_DIRECTORY>"
+}
+SAML_IDP = {
+    "entityId": "https://example.com/saml/metadata/",
+    "singleSignOnService": {
+        "url": "https://example.com/trust/saml2/http-post/sso/",
+        "binding": "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect"
+    },
+    "singleLogoutService": {
+        "url": "https://example.com/trust/saml2/http-redirect/slo/",
+        "binding": "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect"
+    },
+    "x509cert": "<cert here>"
+}
+# or one of:
+# SAML_IDP_FILE = BASE_DIR / 'idp_meta.xml'
+# SAML_IDP_URL = 'https://example.com/saml/metadata/'

--- a/tests/testproject/project/urls.py
+++ b/tests/testproject/project/urls.py
@@ -6,5 +6,6 @@ from django.urls import include, path
 
 urlpatterns = [
     path('admin/', admin.site.urls),
+    path('saml/', include('django_saml.urls')),
     path('', include('cloudprojects.urls')),
 ]

--- a/tox.ini
+++ b/tox.ini
@@ -28,6 +28,7 @@ DJANGO =
 [testenv]
 description = Unit tests
 deps =
+    .[saml]
     coverage[toml]
     pytest-django
     django22: Django>=2.2,<3.0
@@ -65,6 +66,7 @@ commands = isort --check-only --diff {posargs:cloudprojects setup.py tests}
 [testenv:pylint]
 description = Check for errors and code smells
 deps =
+    .[saml]
     django
     pylint-django
 commands =


### PR DESCRIPTION
Adds optional support for SAML single sign-on via [python3-saml-django](https://pypi.org/project/python3-saml-django/). This promises stable support for SAML.

The alternative, [django-allauth-saml2](https://pypi.org/project/django-allauth-saml2/), an extension to Allauth, was unable to get running, unfortunately.