### PR TITLE
Exclude invalid test jobs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,6 +24,10 @@ jobs:
         - '2.2'
         - '3.2'
         - '4.0'
+        exclude:
+        - { django-version: '2.2', python-version: '3.10' }
+        - { django-version: '4.0', python-version: '3.6' }
+        - { django-version: '4.0', python-version: '3.7' }
     steps:
     - uses: actions/checkout@v2
     - uses: actions/setup-python@v2


### PR DESCRIPTION
Valid jobs are spun up by the matrix expansion in `tox.ini`, but in GHA they need to be excluded from the test matrix.