### PR TITLE
Modernize Tox setup, update Python/Django combinations

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -19,12 +19,12 @@ jobs:
         - flake8
         - pylint
         - bandit
-        - readme
+        - package
     steps:
     - uses: actions/checkout@v2
     - uses: actions/setup-python@v2
       with:
-        python-version: '3.8'
+        python-version: '3.10'
     - name: Install prerequistes for SAML
       if: ${{ matrix.env == 'pylint' }}
       run: |

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -20,6 +20,7 @@ jobs:
         - pylint
         - bandit
         - package
+        - requirements
     steps:
     - uses: actions/checkout@v2
     - uses: actions/setup-python@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,19 +15,19 @@ jobs:
       fail-fast: false
       matrix:
         python-version:
-        - '3.6'
         - '3.7'
         - '3.8'
         - '3.9'
         - '3.10'
+        - '3.11'
         django-version:
-        - '2.2'
         - '3.2'
         - '4.0'
+        - '4.1'
         exclude:
-        - { django-version: '2.2', python-version: '3.10' }
-        - { django-version: '4.0', python-version: '3.6' }
         - { django-version: '4.0', python-version: '3.7' }
+        - { django-version: '4.0', python-version: '3.11' }
+        - { django-version: '4.1', python-version: '3.7' }
     steps:
     - uses: actions/checkout@v2
     - uses: actions/setup-python@v2

--- a/README.rst
+++ b/README.rst
@@ -170,8 +170,8 @@ You may use the included `test project`_ for developing interactively, e.g.
 .. code:: console
 
     pip install .[saml]
-    pip install pip-tools tox
-    pip-compile  # generates requirements.txt
+    pip install tox
+    tox -e requirements  # generates requirements.txt
 
 Set ``DEBUG = True`` in Django settings to persist changes in a local database,
 e.g.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,12 +1,14 @@
 [tool.bandit]
-# Exclude/ignore of files is currently broken in Bandit.
-exclude = [".cache",".git",".github",".tox","build","dist","tests"]
+exclude_dirs = [".cache",".git",".github",".tox","build","dist","tests"]
 
 [tool.black]
 color = true
 
 [tool.coverage.run]
 source = ["cloudprojects"]
+
+[tool.coverage.report]
+show_missing = true
 
 [tool.coverage.xml]
 output = "tests/coverage-report.xml"

--- a/tox.ini
+++ b/tox.ini
@@ -5,10 +5,10 @@ envlist =
     pylint
     bandit
     # Python/Django combinations that are officially supported
-    py{36,37,38,39}-django{22}
-    py{36,37,38,39,310}-django{32}
-    py{38,39,310}-django{40}
-    readme
+    py3{6,7,8,9,10}-django{32}
+    py3{8,9,10}-django{40}
+    py3{8,9,10,11}-django{41}
+    package
     clean
 
 [gh-actions]
@@ -18,12 +18,13 @@ python =
     3.8: py38
     3.9: py39
     3.10: py310
+    3.11: py311
 
 [gh-actions:env]
 DJANGO =
-    2.2: django22
     3.2: django32
     4.0: django40
+    4.1: django41
 
 [testenv]
 description = Unit tests
@@ -31,9 +32,9 @@ deps =
     .[saml]
     coverage[toml]
     pytest-django
-    django22: Django>=2.2,<3.0
     django32: Django>=3.2,<4.0
     django40: Django>=4.0,<4.1
+    django41: Django>=4.1,<4.2
 commands =
     coverage run -m pytest {posargs}
     coverage xml
@@ -42,18 +43,20 @@ commands =
 [testenv:bandit]
 description = PyCQA security linter
 skip_install = true
-deps = bandit
-commands = bandit -v {posargs:-r cloudprojects}
+deps = bandit[toml]
+commands = bandit {posargs:-c pyproject.toml -r .}
+
+[testenv:black]
+description = Ensure consistent code style
+skip_install = true
+deps = black
+commands = black {posargs:--check --diff cloudprojects setup.py tests}
 
 [testenv:clean]
-description = Remove Python bytecode and other debris
+description = Remove bytecode and other debris
 skip_install = true
 deps = pyclean
-commands =
-    pyclean {posargs:.}
-    rm -rf .coverage .tox/ django_cloudprojects.egg-info/ build/ dist/ tests/coverage-report.xml tests/unittests-report.xml tests/testproject/project.sqlite3
-allowlist_externals =
-    rm
+commands = pyclean {posargs:. --debris --erase tests/*-report.xml tests/testproject/project.sqlite3 --yes}
 
 [testenv:flake8]
 description = Static code analysis and code style
@@ -67,6 +70,20 @@ skip_install = true
 deps = isort[colors]
 commands = isort --check-only --diff {posargs:cloudprojects setup.py tests}
 
+[testenv:package]
+description = Build package and check metadata (or upload package)
+skip_install = true
+deps =
+    build
+    twine
+commands =
+    python -m build
+    twine {posargs:check --strict} dist/*
+passenv =
+    TWINE_USERNAME
+    TWINE_PASSWORD
+    TWINE_REPOSITORY_URL
+
 [testenv:pylint]
 description = Check for errors and code smells
 deps =
@@ -75,16 +92,6 @@ deps =
     pylint-django
 commands =
     pylint {posargs:cloudprojects setup}
-
-[testenv:readme]
-description = Ensure README renders on PyPI
-skip_install = true
-deps =
-    build
-    twine
-commands =
-    python -m build
-    twine check dist/*
 
 [flake8]
 exclude = .cache,.git,.tox,build,dist,cloudprojects.egg-info

--- a/tox.ini
+++ b/tox.ini
@@ -9,6 +9,7 @@ envlist =
     py3{8,9,10}-django{40}
     py3{8,9,10,11}-django{41}
     package
+    requirements
     clean
 
 [gh-actions]
@@ -92,6 +93,16 @@ deps =
     pylint-django
 commands =
     pylint {posargs:cloudprojects setup}
+
+[testenv:requirements]
+description = Update requirements.txt
+skip_install = true
+deps = pip-tools
+commands =
+    pip-compile --resolver=backtracking --upgrade --quiet
+    git diff --color --exit-code requirements.txt
+allowlist_externals =
+    git
 
 [flake8]
 exclude = .cache,.git,.tox,build,dist,cloudprojects.egg-info


### PR DESCRIPTION
- Updates the Tox configuration with some recent advancements (e.g. new [pyclean](https://pypi.org/project/pyclean/) features, `package` job, Bandit configuration fix in `pyproject.toml`).
- Updates the [officially supported](https://www.djangoproject.com/download/#supported-versions) [Python-Django combinations](https://pypi.org/project/Django/#history) in the test matrix
- Excludes Python 3.6 from testing on GHA to avoid having to stick to GitHub's/Azure's Ubuntu 20.04 image